### PR TITLE
Fixing typo on FloatBorder highlight

### DIFF
--- a/lua/onedarker/highlights.lua
+++ b/lua/onedarker/highlights.lua
@@ -17,7 +17,7 @@ local highlights = {
 		Folded = {fg = C.accent, bg = C.alt_bg, },
 		FoldColumn = {fg = C.accent, bg = C.alt_bg, },
 		LineNr = {fg = C.context, },
-		FloatBoder = {fg = C.gray, bg = C.alt_bg, },
+		FloatBorder = {fg = C.gray, bg = C.alt_bg, },
 		Whitespace = {fg = C.bg, },
 		VertSplit = {fg = C.bg, bg = C.fg, },
 		CursorLine = {bg = C.dark, },


### PR DESCRIPTION
This was bugging me for a while and I thought it was something wrong with my border config!
<img width="323" alt="Screen Shot 2022-03-07 at 12 38 47 PM" src="https://user-images.githubusercontent.com/1333924/157089203-537cc8db-c3d2-43eb-91bd-1581f4f416b4.png">
 
Turns out it was just a typo on the highlights file