### PR TITLE
fix(lualine): add missing colorscheme command

### DIFF
--- a/lua/onedarker/init.lua
+++ b/lua/onedarker/init.lua
@@ -10,6 +10,7 @@ function M.setup()
   vim.o.termguicolors = true
   vim.g.colors_name = "onedarker"
   highlights.setup()
+  vim.cmd [[colorscheme onedarker]]
 end
 
 return M


### PR DESCRIPTION
Lualine relies on `colorscheme` being set to be able to compare certain colors.